### PR TITLE
Some general code and dependencies cleanup 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,15 @@ name = "rwcst"
 [workspace]
 members = [
         "dummy",
+
         "actix_full",
         "actix_reqwest",
         "gotham_reqwest",
         "hyper_full",
         "hyper_reqwest",
-        "warp_surf",
         "tide_surf",
         "warp_reqwest",
+        "warp_surf",
 ]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "rust-web-client-server-testing"
+name = "web-client-server-binary-size-benchmark"
 version = "0.1.0"
 authors = ["Jonathas-Conceicao <jonathas.conceicao@ossystems.com.br"]
 edition = "2018"
 publish = false
 
 [lib]
-name = "rwcst"
+name = "bench"
 
 [workspace]
 members = [

--- a/actix_full/Cargo.toml
+++ b/actix_full/Cargo.toml
@@ -17,4 +17,4 @@ awc = { version = "2.0.0-alpha.1", default-features = false, features = ["compre
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
 futures-util = "0.3"
 openssl = "0.10"
-rwcst = { path = "..", package = "rust-web-client-server-testing" }
+bench = { path = "..", package = "web-client-server-binary-size-benchmark" }

--- a/actix_full/src/main.rs
+++ b/actix_full/src/main.rs
@@ -121,9 +121,6 @@ impl rwcst::AppImpl for App {
             })
         });
 
-        // Give time for the server to actually start
-        std::thread::sleep(std::time::Duration::from_secs(1));
-
         Ok(())
     }
 

--- a/actix_full/src/main.rs
+++ b/actix_full/src/main.rs
@@ -8,15 +8,15 @@ use std::{
     sync::Arc,
 };
 
-use rwcst::prelude::*;
+use bench::prelude::*;
 
 #[actix_rt::main]
 async fn main() {
-    let (url, _guards) = rwcst::start_remote_mock();
+    let (url, _guards) = bench::start_remote_mock();
     let local_client = LocalClient::new();
     let remote_client = RemoteClient::new(&url);
     let app = App::new(remote_client);
-    rwcst::run(local_client, app).await;
+    bench::run(local_client, app).await;
 }
 
 struct LocalClient {
@@ -29,7 +29,7 @@ struct RemoteClient {
 }
 
 struct App {
-    info: Arc<Mutex<rwcst::Info>>,
+    info: Arc<Mutex<bench::Info>>,
     client: RemoteClient,
 }
 
@@ -39,25 +39,25 @@ enum Err {
     Client(awc::error::SendRequestError),
     JsonPayload(awc::error::JsonPayloadError),
     Payload(awc::error::PayloadError),
-    Parsing(rwcst::ParsingError),
+    Parsing(bench::ParsingError),
 }
 type Result<T> = std::result::Result<T, Err>;
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::LocalClientImpl for LocalClient {
+impl bench::LocalClientImpl for LocalClient {
     type Err = Err;
 
     fn new() -> Self {
         LocalClient { client: awc::Client::default() }
     }
 
-    async fn fetch_info(&mut self) -> Result<rwcst::Info> {
+    async fn fetch_info(&mut self) -> Result<bench::Info> {
         Ok(self.client.get("http://localhost:8001").send().await?.json().await?)
     }
 }
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::RemoteClientImpl for RemoteClient {
+impl bench::RemoteClientImpl for RemoteClient {
     type Err = Err;
 
     fn new(remote: &str) -> Self {
@@ -74,14 +74,14 @@ impl rwcst::RemoteClientImpl for RemoteClient {
         }
     }
 
-    async fn fetch_package(&mut self) -> Result<Option<(rwcst::Package, rwcst::Signature)>> {
+    async fn fetch_package(&mut self) -> Result<Option<(bench::Package, bench::Signature)>> {
         let mut response = self.client.get(&self.remote).send().await?;
 
         if let actix_web::http::StatusCode::OK = response.status() {
-            let sign = rwcst::Signature::from_base64_str(
+            let sign = bench::Signature::from_base64_str(
                 &response.headers().get("Signature").unwrap().to_str().unwrap(),
             );
-            let pkg = rwcst::Package::parse(&response.body().await?)?;
+            let pkg = bench::Package::parse(&response.body().await?)?;
             return Ok(Some((pkg, sign)));
         }
 
@@ -90,7 +90,7 @@ impl rwcst::RemoteClientImpl for RemoteClient {
 }
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::AppImpl for App {
+impl bench::AppImpl for App {
     type Err = Err;
     type RemoteClient = RemoteClient;
 
@@ -102,7 +102,7 @@ impl rwcst::AppImpl for App {
     fn serve(&mut self) -> Result<()> {
         #[actix_web::get("/")]
         async fn info(
-            info: actix_web::web::Data<Arc<Mutex<rwcst::Info>>>,
+            info: actix_web::web::Data<Arc<Mutex<bench::Info>>>,
         ) -> actix_web::HttpResponse {
             actix_web::HttpResponse::Ok().json(info.lock().await.deref())
         }
@@ -126,7 +126,7 @@ impl rwcst::AppImpl for App {
         Ok(())
     }
 
-    async fn map_info<F: FnOnce(&mut rwcst::Info)>(&mut self, f: F) -> Result<()> {
+    async fn map_info<F: FnOnce(&mut bench::Info)>(&mut self, f: F) -> Result<()> {
         Ok(f(self.info.lock().await.deref_mut()))
     }
 

--- a/actix_reqwest/Cargo.toml
+++ b/actix_reqwest/Cargo.toml
@@ -16,4 +16,4 @@ async-trait = "0.1"
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
 futures-util = "0.3"
 reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls"] }
-rwcst = { path = "..", package = "rust-web-client-server-testing" }
+bench = { path = "..", package = "web-client-server-binary-size-benchmark" }

--- a/actix_reqwest/src/main.rs
+++ b/actix_reqwest/src/main.rs
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use futures_util::lock::Mutex;
-use std::sync::Arc;
+use std::{
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
 
 use rwcst::prelude::*;
 
@@ -89,14 +92,13 @@ impl rwcst::AppImpl for App {
         async fn info(
             info: actix_web::web::Data<Arc<Mutex<rwcst::Info>>>,
         ) -> actix_web::HttpResponse {
-            use std::ops::Deref;
             actix_web::HttpResponse::Ok().json(info.lock().await.deref())
         }
 
         let info_ref = self.info.clone();
+        // Start server a new thread since the runtime is single threaded
         actix_rt::Arbiter::new().exec_fn(|| {
-            actix_rt::Arbiter::spawn(async move {
-                let info_ref = info_ref;
+            actix_rt::Arbiter::spawn(async {
                 actix_web::HttpServer::new(move || {
                     actix_web::App::new().data(info_ref.clone()).service(info)
                 })
@@ -113,7 +115,6 @@ impl rwcst::AppImpl for App {
     }
 
     async fn map_info<F: FnOnce(&mut rwcst::Info)>(&mut self, f: F) -> Result<()> {
-        use std::ops::DerefMut;
         Ok(f(self.info.lock().await.deref_mut()))
     }
 

--- a/actix_reqwest/src/main.rs
+++ b/actix_reqwest/src/main.rs
@@ -109,9 +109,6 @@ impl rwcst::AppImpl for App {
             })
         });
 
-        // Give time for the server to actually start
-        std::thread::sleep(std::time::Duration::from_secs(1));
-
         Ok(())
     }
 

--- a/dummy/Cargo.toml
+++ b/dummy/Cargo.toml
@@ -11,5 +11,5 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
-rwcst = { path = "..", package = "rust-web-client-server-testing" }
+bench = { path = "..", package = "web-client-server-binary-size-benchmark" }
 tokio = { version = "0.2", features = ["macros"] }

--- a/gotham_reqwest/Cargo.toml
+++ b/gotham_reqwest/Cargo.toml
@@ -15,6 +15,6 @@ gotham = { git = "https://github.com/gotham-rs/gotham", package = "gotham" }
 gotham_derive = { git = "https://github.com/gotham-rs/gotham", package = "gotham_derive" }
 mime = "0.3"
 reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls"] }
-rwcst = { path = "..", package = "rust-web-client-server-testing" }
+bench = { path = "..", package = "web-client-server-binary-size-benchmark" }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 tokio = { version = "0.2", features = ["macros"] }

--- a/gotham_reqwest/Cargo.toml
+++ b/gotham_reqwest/Cargo.toml
@@ -11,11 +11,10 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1"
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
-futures-util = "0.3"
 gotham = { git = "https://github.com/gotham-rs/gotham", package = "gotham" }
 gotham_derive = { git = "https://github.com/gotham-rs/gotham", package = "gotham_derive" }
+mime = "0.3"
 reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls"] }
 rwcst = { path = "..", package = "rust-web-client-server-testing" }
-serde_json = "1.0"
+serde_json = { version = "1", default-features = false, features = ["std"] }
 tokio = { version = "0.2", features = ["macros"] }
-mime = "0.3"

--- a/gotham_reqwest/src/main.rs
+++ b/gotham_reqwest/src/main.rs
@@ -8,15 +8,15 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use rwcst::prelude::*;
+use bench::prelude::*;
 
 #[tokio::main]
 async fn main() {
-    let (url, _guards) = rwcst::start_remote_mock();
+    let (url, _guards) = bench::start_remote_mock();
     let local_client = LocalClient::new();
     let remote_client = RemoteClient::new(&url);
     let app = App::new(remote_client);
-    rwcst::run(local_client, app).await;
+    bench::run(local_client, app).await;
 }
 
 struct LocalClient {
@@ -29,7 +29,7 @@ struct RemoteClient {
 }
 
 struct App {
-    info: Arc<Mutex<rwcst::Info>>,
+    info: Arc<Mutex<bench::Info>>,
     client: RemoteClient,
 }
 
@@ -37,7 +37,7 @@ struct App {
 enum Err {
     Server(gotham::error::Error),
     Client(reqwest::Error),
-    Parsing(rwcst::ParsingError),
+    Parsing(bench::ParsingError),
     MutexPosion,
 }
 
@@ -50,34 +50,34 @@ impl<T> From<std::sync::PoisonError<T>> for Err {
 type Result<T> = std::result::Result<T, Err>;
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::LocalClientImpl for LocalClient {
+impl bench::LocalClientImpl for LocalClient {
     type Err = Err;
 
     fn new() -> Self {
         LocalClient { client: reqwest::Client::new() }
     }
 
-    async fn fetch_info(&mut self) -> Result<rwcst::Info> {
+    async fn fetch_info(&mut self) -> Result<bench::Info> {
         Ok(self.client.get("http://localhost:8001").send().await?.json().await?)
     }
 }
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::RemoteClientImpl for RemoteClient {
+impl bench::RemoteClientImpl for RemoteClient {
     type Err = Err;
 
     fn new(remote: &str) -> Self {
         RemoteClient { client: reqwest::Client::new(), remote: remote.to_owned() }
     }
 
-    async fn fetch_package(&mut self) -> Result<Option<(rwcst::Package, rwcst::Signature)>> {
+    async fn fetch_package(&mut self) -> Result<Option<(bench::Package, bench::Signature)>> {
         let response = self.client.get(&self.remote).send().await?;
 
         if let reqwest::StatusCode::OK = response.status() {
-            let sign = rwcst::Signature::from_base64_str(
+            let sign = bench::Signature::from_base64_str(
                 &response.headers().get("Signature").unwrap().to_str().unwrap(),
             );
-            let pkg = rwcst::Package::parse(&response.bytes().await?)?;
+            let pkg = bench::Package::parse(&response.bytes().await?)?;
             return Ok(Some((pkg, sign)));
         }
 
@@ -86,7 +86,7 @@ impl rwcst::RemoteClientImpl for RemoteClient {
 }
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::AppImpl for App {
+impl bench::AppImpl for App {
     type Err = Err;
     type RemoteClient = RemoteClient;
 
@@ -108,7 +108,7 @@ impl rwcst::AppImpl for App {
         use gotham_derive::StateData;
 
         #[derive(Clone, StateData)]
-        struct Info(Arc<Mutex<rwcst::Info>>);
+        struct Info(Arc<Mutex<bench::Info>>);
 
         async fn handle(state: State) -> HandlerResult {
             let res = match serde_json::to_string(state.borrow::<Info>().0.deref()) {
@@ -138,7 +138,7 @@ impl rwcst::AppImpl for App {
         Ok(())
     }
 
-    async fn map_info<F: FnOnce(&mut rwcst::Info)>(&mut self, f: F) -> Result<()> {
+    async fn map_info<F: FnOnce(&mut bench::Info)>(&mut self, f: F) -> Result<()> {
         Ok(f(self.info.lock()?.deref_mut()))
     }
 

--- a/hyper_full/Cargo.toml
+++ b/hyper_full/Cargo.toml
@@ -14,6 +14,6 @@ derive_more = { version = "0.99", default-features = false, features = ["from", 
 futures-util = "0.3"
 http = "0.2"
 hyper = { version = "0.13", default-features = false, features = ["tcp"] }
-rwcst = { path = "..", package = "rust-web-client-server-testing" }
+bench = { path = "..", package = "web-client-server-binary-size-benchmark" }
 serde_json = "1.0"
 tokio = { version = "0.2", features = ["macros"] }

--- a/hyper_full/Cargo.toml
+++ b/hyper_full/Cargo.toml
@@ -12,9 +12,8 @@ edition = "2018"
 async-trait = "0.1"
 derive_more = { version = "0.99", default-features = false, features = ["from", "display", "error"] }
 futures-util = "0.3"
-hyper = "0.13"
 http = "0.2"
+hyper = { version = "0.13", default-features = false, features = ["tcp"] }
 rwcst = { path = "..", package = "rust-web-client-server-testing" }
-tokio = { version = "0.2", features = ["macros"] }
 serde_json = "1.0"
-bytes = "0.5.4"
+tokio = { version = "0.2", features = ["macros"] }

--- a/hyper_full/src/main.rs
+++ b/hyper_full/src/main.rs
@@ -15,15 +15,15 @@ use std::{
     sync::Arc,
 };
 
-use rwcst::prelude::*;
+use bench::prelude::*;
 
 #[tokio::main]
 async fn main() {
-    let (url, _guards) = rwcst::start_remote_mock();
+    let (url, _guards) = bench::start_remote_mock();
     let local_client = LocalClient::new();
     let remote_client = RemoteClient::new(&url);
     let app = App::new(remote_client);
-    rwcst::run(local_client, app).await;
+    bench::run(local_client, app).await;
 }
 
 struct LocalClient {
@@ -36,27 +36,27 @@ struct RemoteClient {
 }
 
 struct App {
-    info: Arc<Mutex<rwcst::Info>>,
+    info: Arc<Mutex<bench::Info>>,
     client: RemoteClient,
 }
 
 #[derive(Debug, Display, From, Error)]
 enum Err {
     Hyper(hyper::Error),
-    Parsing(rwcst::ParsingError),
+    Parsing(bench::ParsingError),
     Uri(http::uri::InvalidUri),
 }
 type Result<T> = std::result::Result<T, Err>;
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::LocalClientImpl for LocalClient {
+impl bench::LocalClientImpl for LocalClient {
     type Err = Err;
 
     fn new() -> Self {
         LocalClient { client: hyper::Client::new() }
     }
 
-    async fn fetch_info(&mut self) -> Result<rwcst::Info> {
+    async fn fetch_info(&mut self) -> Result<bench::Info> {
         let res = self.client.get("http://localhost:8001".parse()?).await?;
         let body = hyper::body::aggregate(res).await?;
         Ok(serde_json::from_slice(body.bytes())?)
@@ -64,22 +64,22 @@ impl rwcst::LocalClientImpl for LocalClient {
 }
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::RemoteClientImpl for RemoteClient {
+impl bench::RemoteClientImpl for RemoteClient {
     type Err = Err;
 
     fn new(remote: &str) -> Self {
         RemoteClient { client: hyper::Client::new(), remote: remote.to_owned() }
     }
 
-    async fn fetch_package(&mut self) -> Result<Option<(rwcst::Package, rwcst::Signature)>> {
+    async fn fetch_package(&mut self) -> Result<Option<(bench::Package, bench::Signature)>> {
         let response = self.client.get(self.remote.clone().parse()?).await?;
 
         if let StatusCode::OK = response.status() {
-            let sign = rwcst::Signature::from_base64_str(
+            let sign = bench::Signature::from_base64_str(
                 &response.headers().get("Signature").unwrap().to_str().unwrap(),
             );
             let body = hyper::body::aggregate(response).await?;
-            let pkg = rwcst::Package::parse(&body.bytes())?;
+            let pkg = bench::Package::parse(&body.bytes())?;
             return Ok(Some((pkg, sign)));
         }
 
@@ -88,7 +88,7 @@ impl rwcst::RemoteClientImpl for RemoteClient {
 }
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::AppImpl for App {
+impl bench::AppImpl for App {
     type Err = Err;
     type RemoteClient = RemoteClient;
 
@@ -128,7 +128,7 @@ impl rwcst::AppImpl for App {
         Ok(())
     }
 
-    async fn map_info<F: FnOnce(&mut rwcst::Info)>(&mut self, f: F) -> Result<()> {
+    async fn map_info<F: FnOnce(&mut bench::Info)>(&mut self, f: F) -> Result<()> {
         Ok(f(self.info.lock().await.deref_mut()))
     }
 

--- a/hyper_full/src/main.rs
+++ b/hyper_full/src/main.rs
@@ -4,13 +4,17 @@
 
 use derive_more::{Display, Error, From};
 use futures_util::lock::Mutex;
-use std::{convert::Infallible, sync::Arc};
-
-use bytes::buf::BufExt;
 use hyper::{
+    body::Buf,
     service::{make_service_fn, service_fn},
-    Body, Method, Request, Response, Server, StatusCode,
+    Body, Method, Response, Server, StatusCode,
 };
+use std::{
+    convert::Infallible,
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
+
 use rwcst::prelude::*;
 
 #[tokio::main]
@@ -40,7 +44,6 @@ struct App {
 enum Err {
     Hyper(hyper::Error),
     Parsing(rwcst::ParsingError),
-    Http(http::Error),
     Uri(http::uri::InvalidUri),
 }
 type Result<T> = std::result::Result<T, Err>;
@@ -56,7 +59,7 @@ impl rwcst::LocalClientImpl for LocalClient {
     async fn fetch_info(&mut self) -> Result<rwcst::Info> {
         let res = self.client.get("http://localhost:8001".parse()?).await?;
         let body = hyper::body::aggregate(res).await?;
-        Ok(serde_json::from_reader(body.reader())?)
+        Ok(serde_json::from_slice(body.bytes())?)
     }
 }
 
@@ -75,7 +78,8 @@ impl rwcst::RemoteClientImpl for RemoteClient {
             let sign = rwcst::Signature::from_base64_str(
                 &response.headers().get("Signature").unwrap().to_str().unwrap(),
             );
-            let pkg = rwcst::Package::parse(&hyper::body::to_bytes(response.into_body()).await?)?;
+            let body = hyper::body::aggregate(response).await?;
+            let pkg = rwcst::Package::parse(&body.bytes())?;
             return Ok(Some((pkg, sign)));
         }
 
@@ -94,32 +98,26 @@ impl rwcst::AppImpl for App {
     }
 
     fn serve(&mut self) -> Result<()> {
-        async fn handle(
-            req: Request<Body>,
-            state: Arc<Mutex<rwcst::Info>>,
-        ) -> Result<Response<Body>> {
-            match (req.method(), req.uri().path()) {
-                (&Method::GET, "/") => {
-                    use std::ops::Deref;
-
-                    let state = state.lock().await;
-                    let body = serde_json::to_string(&state.deref())?;
-                    Ok(Response::new(Body::from(body)))
-                }
-                _ => {
-                    let mut not_found = Response::default();
-                    *not_found.status_mut() = StatusCode::NOT_FOUND;
-                    Ok(not_found)
-                }
-            }
-        }
         let state = self.info.clone();
         let make_svc = make_service_fn(move |_conn| {
             let state = state.clone();
-            async move {
-                Ok::<_, Infallible>(service_fn(move |req: Request<Body>| {
+            async {
+                Ok::<_, Infallible>(service_fn(move |req| {
                     let state = state.clone();
-                    handle(req, state)
+                    async move {
+                        match (req.method(), req.uri().path()) {
+                            (&Method::GET, "/") => {
+                                let state = state.lock().await;
+                                let body = serde_json::to_string(&state.deref())?;
+                                Ok(Response::new(Body::from(body)))
+                            }
+                            _ => {
+                                let mut not_found = Response::default();
+                                *not_found.status_mut() = StatusCode::NOT_FOUND;
+                                Ok::<_, Err>(not_found)
+                            }
+                        }
+                    }
                 }))
             }
         });
@@ -131,7 +129,6 @@ impl rwcst::AppImpl for App {
     }
 
     async fn map_info<F: FnOnce(&mut rwcst::Info)>(&mut self, f: F) -> Result<()> {
-        use std::ops::DerefMut;
         Ok(f(self.info.lock().await.deref_mut()))
     }
 

--- a/hyper_reqwest/Cargo.toml
+++ b/hyper_reqwest/Cargo.toml
@@ -12,9 +12,8 @@ edition = "2018"
 async-trait = "0.1"
 derive_more = { version = "0.99", default-features = false, features = ["from", "display", "error"] }
 futures-util = "0.3"
-hyper = "0.13"
+hyper = { version = "0.13", default-features = false }
 reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls"] }
-http = "0.2"
 rwcst = { path = "..", package = "rust-web-client-server-testing" }
-tokio = { version = "0.2", features = ["macros"] }
 serde_json = "1.0"
+tokio = { version = "0.2", features = ["macros"] }

--- a/hyper_reqwest/Cargo.toml
+++ b/hyper_reqwest/Cargo.toml
@@ -14,6 +14,6 @@ derive_more = { version = "0.99", default-features = false, features = ["from", 
 futures-util = "0.3"
 hyper = { version = "0.13", default-features = false }
 reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls"] }
-rwcst = { path = "..", package = "rust-web-client-server-testing" }
+bench = { path = "..", package = "web-client-server-binary-size-benchmark" }
 serde_json = "1.0"
 tokio = { version = "0.2", features = ["macros"] }

--- a/hyper_reqwest/src/main.rs
+++ b/hyper_reqwest/src/main.rs
@@ -14,15 +14,15 @@ use std::{
     sync::Arc,
 };
 
-use rwcst::prelude::*;
+use bench::prelude::*;
 
 #[tokio::main]
 async fn main() {
-    let (url, _guards) = rwcst::start_remote_mock();
+    let (url, _guards) = bench::start_remote_mock();
     let local_client = LocalClient::new();
     let remote_client = RemoteClient::new(&url);
     let app = App::new(remote_client);
-    rwcst::run(local_client, app).await;
+    bench::run(local_client, app).await;
 }
 
 struct LocalClient {
@@ -35,7 +35,7 @@ struct RemoteClient {
 }
 
 struct App {
-    info: Arc<Mutex<rwcst::Info>>,
+    info: Arc<Mutex<bench::Info>>,
     client: RemoteClient,
 }
 
@@ -43,39 +43,39 @@ struct App {
 enum Err {
     Server(hyper::Error),
     Client(reqwest::Error),
-    Parsing(rwcst::ParsingError),
+    Parsing(bench::ParsingError),
 }
 type Result<T> = std::result::Result<T, Err>;
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::LocalClientImpl for LocalClient {
+impl bench::LocalClientImpl for LocalClient {
     type Err = Err;
 
     fn new() -> Self {
         LocalClient { client: reqwest::Client::new() }
     }
 
-    async fn fetch_info(&mut self) -> Result<rwcst::Info> {
+    async fn fetch_info(&mut self) -> Result<bench::Info> {
         Ok(self.client.get("http://localhost:8001").send().await?.json().await?)
     }
 }
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::RemoteClientImpl for RemoteClient {
+impl bench::RemoteClientImpl for RemoteClient {
     type Err = Err;
 
     fn new(remote: &str) -> Self {
         RemoteClient { client: reqwest::Client::new(), remote: remote.to_owned() }
     }
 
-    async fn fetch_package(&mut self) -> Result<Option<(rwcst::Package, rwcst::Signature)>> {
+    async fn fetch_package(&mut self) -> Result<Option<(bench::Package, bench::Signature)>> {
         let response = self.client.get(&self.remote).send().await?;
 
         if let reqwest::StatusCode::OK = response.status() {
-            let sign = rwcst::Signature::from_base64_str(
+            let sign = bench::Signature::from_base64_str(
                 &response.headers().get("Signature").unwrap().to_str().unwrap(),
             );
-            let pkg = rwcst::Package::parse(&response.bytes().await?)?;
+            let pkg = bench::Package::parse(&response.bytes().await?)?;
             return Ok(Some((pkg, sign)));
         }
 
@@ -84,7 +84,7 @@ impl rwcst::RemoteClientImpl for RemoteClient {
 }
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::AppImpl for App {
+impl bench::AppImpl for App {
     type Err = Err;
     type RemoteClient = RemoteClient;
 
@@ -124,7 +124,7 @@ impl rwcst::AppImpl for App {
         Ok(())
     }
 
-    async fn map_info<F: FnOnce(&mut rwcst::Info)>(&mut self, f: F) -> Result<()> {
+    async fn map_info<F: FnOnce(&mut bench::Info)>(&mut self, f: F) -> Result<()> {
         Ok(f(self.info.lock().await.deref_mut()))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,9 @@ pub trait AppImpl: Sized {
 pub async fn run<C: LocalClientImpl, A: AppImpl>(mut client: C, mut app: A) {
     app.serve().unwrap(); // Start serving the app for the local client
 
+    // Give time for the server to actually start
+    std::thread::sleep(std::time::Duration::from_secs(1));
+
     let info = client.fetch_info().await.unwrap();
     assert_eq!(info, Info::default(), "Info should be default as nothing has run so far");
 

--- a/tide_surf/Cargo.toml
+++ b/tide_surf/Cargo.toml
@@ -14,6 +14,6 @@ async-std = { version = "1", default-features = false, features = ["attributes"]
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
 futures-util = "0.3"
 rwcst = { path = "..", package = "rust-web-client-server-testing" }
-surf = "2.0.0-alpha.4"
-http-client = "3.0"
-tide = "0.11"
+surf = { version = "2.0.0-alpha.4", default-features = false, features = ["h1-client"] }
+http-client = { version = "3.0", default-features = false, features = ["h1_client"] }
+tide = { version = "0.11", default-features = false, features = ["h1-server"] }

--- a/tide_surf/Cargo.toml
+++ b/tide_surf/Cargo.toml
@@ -13,7 +13,7 @@ async-trait = "0.1"
 async-std = { version = "1", default-features = false, features = ["attributes"] }
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
 futures-util = "0.3"
-rwcst = { path = "..", package = "rust-web-client-server-testing" }
+bench = { path = "..", package = "web-client-server-binary-size-benchmark" }
 surf = { version = "2.0.0-alpha.4", default-features = false, features = ["h1-client"] }
 http-client = { version = "3.0", default-features = false, features = ["h1_client"] }
 tide = { version = "0.11", default-features = false, features = ["h1-server"] }

--- a/tide_surf/src/main.rs
+++ b/tide_surf/src/main.rs
@@ -10,15 +10,15 @@ use std::{
     sync::Arc,
 };
 
-use rwcst::prelude::*;
+use bench::prelude::*;
 
 #[async_std::main]
 async fn main() {
-    let (url, _guards) = rwcst::start_remote_mock();
+    let (url, _guards) = bench::start_remote_mock();
     let local_client = LocalClient::new();
     let remote_client = RemoteClient::new(&url);
     let app = App::new(remote_client);
-    rwcst::run(local_client, app).await;
+    bench::run(local_client, app).await;
 }
 
 struct LocalClient {
@@ -31,46 +31,46 @@ struct RemoteClient {
 }
 
 struct App {
-    info: Arc<Mutex<rwcst::Info>>,
+    info: Arc<Mutex<bench::Info>>,
     client: RemoteClient,
 }
 
 #[derive(Debug, From)]
 enum Err {
     Http(tide::Error),
-    Parsing(rwcst::ParsingError),
+    Parsing(bench::ParsingError),
     Io(std::io::Error),
 }
 type Result<T> = std::result::Result<T, Err>;
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::LocalClientImpl for LocalClient {
+impl bench::LocalClientImpl for LocalClient {
     type Err = Err;
 
     fn new() -> Self {
         LocalClient { client: surf::Client::new() }
     }
 
-    async fn fetch_info(&mut self) -> Result<rwcst::Info> {
+    async fn fetch_info(&mut self) -> Result<bench::Info> {
         Ok(self.client.get("http://127.0.0.1:8001").recv_json().await?)
     }
 }
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::RemoteClientImpl for RemoteClient {
+impl bench::RemoteClientImpl for RemoteClient {
     type Err = Err;
 
     fn new(remote: &str) -> Self {
         RemoteClient { client: surf::Client::new(), remote: remote.to_owned() }
     }
 
-    async fn fetch_package(&mut self) -> Result<Option<(rwcst::Package, rwcst::Signature)>> {
+    async fn fetch_package(&mut self) -> Result<Option<(bench::Package, bench::Signature)>> {
         let mut response = self.client.get(&self.remote).await?;
 
         if let surf::http_types::StatusCode::Ok = response.status() {
             let sign =
-                rwcst::Signature::from_base64_str(&response.header("signature").unwrap().as_str());
-            let pkg = rwcst::Package::parse(&response.body_bytes().await?)?;
+                bench::Signature::from_base64_str(&response.header("signature").unwrap().as_str());
+            let pkg = bench::Package::parse(&response.body_bytes().await?)?;
             return Ok(Some((pkg, sign)));
         }
 
@@ -79,7 +79,7 @@ impl rwcst::RemoteClientImpl for RemoteClient {
 }
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::AppImpl for App {
+impl bench::AppImpl for App {
     type Err = Err;
     type RemoteClient = RemoteClient;
 
@@ -91,7 +91,7 @@ impl rwcst::AppImpl for App {
     fn serve(&mut self) -> Result<()> {
         let state = self.info.clone();
         let mut app = tide::with_state(state);
-        app.at("/").get(|req: tide::Request<Arc<Mutex<rwcst::Info>>>| async move {
+        app.at("/").get(|req: tide::Request<Arc<Mutex<bench::Info>>>| async move {
             let state = &req.state().lock().await;
             let mut res = tide::Response::new(200);
             res.set_body(tide::Body::from_json(&state.deref())?);
@@ -103,7 +103,7 @@ impl rwcst::AppImpl for App {
         Ok(())
     }
 
-    async fn map_info<F: FnOnce(&mut rwcst::Info)>(&mut self, f: F) -> Result<()> {
+    async fn map_info<F: FnOnce(&mut bench::Info)>(&mut self, f: F) -> Result<()> {
         Ok(f(self.info.lock().await.deref_mut()))
     }
 

--- a/warp_reqwest/Cargo.toml
+++ b/warp_reqwest/Cargo.toml
@@ -13,6 +13,6 @@ async-trait = "0.1"
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
 futures-util = "0.3"
 reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls"] }
-rwcst = { path = "..", package = "rust-web-client-server-testing" }
+bench = { path = "..", package = "web-client-server-binary-size-benchmark" }
 tokio = { version = "0.2", features = ["macros"] }
 warp = { version = "0.2", default-features = false }

--- a/warp_reqwest/Cargo.toml
+++ b/warp_reqwest/Cargo.toml
@@ -15,4 +15,4 @@ futures-util = "0.3"
 reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls"] }
 rwcst = { path = "..", package = "rust-web-client-server-testing" }
 tokio = { version = "0.2", features = ["macros"] }
-warp = "0.2"
+warp = { version = "0.2", default-features = false }

--- a/warp_reqwest/src/main.rs
+++ b/warp_reqwest/src/main.rs
@@ -9,15 +9,15 @@ use std::{
     sync::Arc,
 };
 
-use rwcst::prelude::*;
+use bench::prelude::*;
 
 #[tokio::main]
 async fn main() {
-    let (url, _guards) = rwcst::start_remote_mock();
+    let (url, _guards) = bench::start_remote_mock();
     let local_client = LocalClient::new();
     let remote_client = RemoteClient::new(&url);
     let app = App::new(remote_client);
-    rwcst::run(local_client, app).await;
+    bench::run(local_client, app).await;
 }
 
 struct LocalClient {
@@ -30,7 +30,7 @@ struct RemoteClient {
 }
 
 struct App {
-    info: Arc<Mutex<rwcst::Info>>,
+    info: Arc<Mutex<bench::Info>>,
     client: RemoteClient,
 }
 
@@ -38,39 +38,39 @@ struct App {
 enum Err {
     Server(warp::Error),
     Client(reqwest::Error),
-    Parsing(rwcst::ParsingError),
+    Parsing(bench::ParsingError),
 }
 type Result<T> = std::result::Result<T, Err>;
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::LocalClientImpl for LocalClient {
+impl bench::LocalClientImpl for LocalClient {
     type Err = Err;
 
     fn new() -> Self {
         LocalClient { client: reqwest::Client::new() }
     }
 
-    async fn fetch_info(&mut self) -> Result<rwcst::Info> {
+    async fn fetch_info(&mut self) -> Result<bench::Info> {
         Ok(self.client.get("http://localhost:8001").send().await?.json().await?)
     }
 }
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::RemoteClientImpl for RemoteClient {
+impl bench::RemoteClientImpl for RemoteClient {
     type Err = Err;
 
     fn new(remote: &str) -> Self {
         RemoteClient { client: reqwest::Client::new(), remote: remote.to_owned() }
     }
 
-    async fn fetch_package(&mut self) -> Result<Option<(rwcst::Package, rwcst::Signature)>> {
+    async fn fetch_package(&mut self) -> Result<Option<(bench::Package, bench::Signature)>> {
         let response = self.client.get(&self.remote).send().await?;
 
         if let reqwest::StatusCode::OK = response.status() {
-            let sign = rwcst::Signature::from_base64_str(
+            let sign = bench::Signature::from_base64_str(
                 &response.headers().get("Signature").unwrap().to_str().unwrap(),
             );
-            let pkg = rwcst::Package::parse(&response.bytes().await?)?;
+            let pkg = bench::Package::parse(&response.bytes().await?)?;
             return Ok(Some((pkg, sign)));
         }
 
@@ -79,7 +79,7 @@ impl rwcst::RemoteClientImpl for RemoteClient {
 }
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::AppImpl for App {
+impl bench::AppImpl for App {
     type Err = Err;
     type RemoteClient = RemoteClient;
 
@@ -107,7 +107,7 @@ impl rwcst::AppImpl for App {
         Ok(())
     }
 
-    async fn map_info<F: FnOnce(&mut rwcst::Info)>(&mut self, f: F) -> Result<()> {
+    async fn map_info<F: FnOnce(&mut bench::Info)>(&mut self, f: F) -> Result<()> {
         Ok(f(self.info.lock().await.deref_mut()))
     }
 

--- a/warp_reqwest/src/main.rs
+++ b/warp_reqwest/src/main.rs
@@ -2,8 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use derive_more::From;
 use futures_util::lock::Mutex;
-use std::sync::Arc;
+use std::{
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
 
 use rwcst::prelude::*;
 
@@ -30,7 +34,7 @@ struct App {
     client: RemoteClient,
 }
 
-#[derive(Debug, derive_more::From)]
+#[derive(Debug, From)]
 enum Err {
     Server(warp::Error),
     Client(reqwest::Error),
@@ -85,8 +89,8 @@ impl rwcst::AppImpl for App {
     }
 
     fn serve(&mut self) -> Result<()> {
-        use std::ops::Deref;
         use warp::{reject::Rejection, reply::Json, Filter};
+
         type Result = std::result::Result<Json, Rejection>;
 
         let state = self.info.clone();
@@ -104,7 +108,6 @@ impl rwcst::AppImpl for App {
     }
 
     async fn map_info<F: FnOnce(&mut rwcst::Info)>(&mut self, f: F) -> Result<()> {
-        use std::ops::DerefMut;
         Ok(f(self.info.lock().await.deref_mut()))
     }
 

--- a/warp_surf/Cargo.toml
+++ b/warp_surf/Cargo.toml
@@ -9,11 +9,12 @@ authors = ["asakiz <asakizin@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+async-std = { version = "1", default-features = false, features = ["tokio02"] }
 async-trait = "0.1"
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
 futures-util = "0.3"
+http-client = { version = "3.0", default-features = false, features = ["h1_client"] }
 rwcst = { path = "..", package = "rust-web-client-server-testing" }
-tokio = { version = "0.2", features = ["macros"] }
+surf = { version = "2.0.0-alpha.4", default-features = false, features = ["h1-client"] }
+tokio = { version = "0.2", features = ["macros", "rt-core"] }
 warp = "0.2"
-surf = "2.0.0-alpha.4"
-http-client = "3.0"

--- a/warp_surf/Cargo.toml
+++ b/warp_surf/Cargo.toml
@@ -14,7 +14,7 @@ async-trait = "0.1"
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
 futures-util = "0.3"
 http-client = { version = "3.0", default-features = false, features = ["h1_client"] }
-rwcst = { path = "..", package = "rust-web-client-server-testing" }
+bench = { path = "..", package = "web-client-server-binary-size-benchmark" }
 surf = { version = "2.0.0-alpha.4", default-features = false, features = ["h1-client"] }
 tokio = { version = "0.2", features = ["macros", "rt-core"] }
 warp = "0.2"

--- a/warp_surf/src/main.rs
+++ b/warp_surf/src/main.rs
@@ -10,15 +10,15 @@ use std::{
     sync::Arc,
 };
 
-use rwcst::prelude::*;
+use bench::prelude::*;
 
 #[tokio::main]
 async fn main() {
-    let (url, _guards) = rwcst::start_remote_mock();
+    let (url, _guards) = bench::start_remote_mock();
     let local_client = LocalClient::new();
     let remote_client = RemoteClient::new(&url);
     let app = App::new(remote_client);
-    rwcst::run(local_client, app).await;
+    bench::run(local_client, app).await;
 }
 
 struct LocalClient {
@@ -31,7 +31,7 @@ struct RemoteClient {
 }
 
 struct App {
-    info: Arc<Mutex<rwcst::Info>>,
+    info: Arc<Mutex<bench::Info>>,
     client: RemoteClient,
 }
 
@@ -39,20 +39,20 @@ struct App {
 enum Err {
     Server(warp::Error),
     Client(surf::Error),
-    Parsing(rwcst::ParsingError),
+    Parsing(bench::ParsingError),
     Io(std::io::Error),
 }
 type Result<T> = std::result::Result<T, Err>;
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::LocalClientImpl for LocalClient {
+impl bench::LocalClientImpl for LocalClient {
     type Err = Err;
 
     fn new() -> Self {
         LocalClient { client: surf::Client::new() }
     }
 
-    async fn fetch_info(&mut self) -> Result<rwcst::Info> {
+    async fn fetch_info(&mut self) -> Result<bench::Info> {
         let req = self.client.get("http://127.0.0.1:8001").recv_json();
         // Use have to use async-std to spawn this future into the tokio runtime
         // otherwise the Surf future wouldn't be awaken after the first
@@ -61,20 +61,20 @@ impl rwcst::LocalClientImpl for LocalClient {
 }
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::RemoteClientImpl for RemoteClient {
+impl bench::RemoteClientImpl for RemoteClient {
     type Err = Err;
 
     fn new(remote: &str) -> Self {
         RemoteClient { client: surf::Client::new(), remote: remote.to_owned() }
     }
 
-    async fn fetch_package(&mut self) -> Result<Option<(rwcst::Package, rwcst::Signature)>> {
+    async fn fetch_package(&mut self) -> Result<Option<(bench::Package, bench::Signature)>> {
         let mut response = self.client.get(&self.remote).await?;
 
         if let surf::http_types::StatusCode::Ok = response.status() {
             let sign =
-                rwcst::Signature::from_base64_str(&response.header("signature").unwrap().as_str());
-            let pkg = rwcst::Package::parse(&response.body_bytes().await?)?;
+                bench::Signature::from_base64_str(&response.header("signature").unwrap().as_str());
+            let pkg = bench::Package::parse(&response.body_bytes().await?)?;
             return Ok(Some((pkg, sign)));
         }
 
@@ -83,7 +83,7 @@ impl rwcst::RemoteClientImpl for RemoteClient {
 }
 
 #[async_trait::async_trait(?Send)]
-impl rwcst::AppImpl for App {
+impl bench::AppImpl for App {
     type Err = Err;
     type RemoteClient = RemoteClient;
 
@@ -110,7 +110,7 @@ impl rwcst::AppImpl for App {
         Ok(())
     }
 
-    async fn map_info<F: FnOnce(&mut rwcst::Info)>(&mut self, f: F) -> Result<()> {
+    async fn map_info<F: FnOnce(&mut bench::Info)>(&mut self, f: F) -> Result<()> {
         Ok(f(self.info.lock().await.deref_mut()))
     }
 


### PR DESCRIPTION
Most of the contestants remained the same size with optimization allowed. At this point I find little to optimize given the examples are already small and straightforward.

The surf and tide based cotestans where moved to use a rust implemented HTTP (async_h1) implementation instead of the native one, which was using curl. This showed a small decresce in binary size. The `reqwest_surf` constant, however, had a slight (close to 1% on -O3 optimization) increase given that now it has to call to both `tokio` and `async_std` so the client future can be awaken after the first `Poll::Pending`.